### PR TITLE
Fix construction of ilDateTime.

### DIFF
--- a/classes/class.ilTestArchiveCreatorSettings.php
+++ b/classes/class.ilTestArchiveCreatorSettings.php
@@ -115,8 +115,8 @@ class ilTestArchiveCreatorSettings
 
 		$query = "SELECT obj_id FROM tarc_ui_settings WHERE status = %s AND schedule <= %s";
 		$result = $db->queryF($query,
-			array('text', 'timestamp'),
-			array(ilTestArchiveCreatorPlugin::STATUS_PLANNED, new ilDateTime(time(), $time->get(IL_CAL_DATETIME)))
+			array('text', 'text'),
+			array(ilTestArchiveCreatorPlugin::STATUS_PLANNED, $time->get(IL_CAL_DATETIME))
 		);
 
 		$obj_ids = array();


### PR DESCRIPTION
Hallo Fred, die Zeitsteuerung hat bei uns nicht funktioniert (hat einfach nicht angeschlagen), und da hab ich mal geschaut, und mir scheint, da hat sich ein Fehler eingeschlichen. Der Konstruktor von `ilDateTime` bekommt momentan kein Format, sondern einen Datestring, das kann so nicht stimmen.

Mit der Änderung klappt es bei uns jetzt minutengenau, aber dafür ist leider der `timestamp` Typ dahin.