### PR TITLE
bugfix from code changes 5.4.5 -> 5.4.6: https://github.com/ILIAS-eLe…

### DIFF
--- a/classes/class.ilTestArchiveCreator.php
+++ b/classes/class.ilTestArchiveCreator.php
@@ -387,7 +387,7 @@ class ilTestArchiveCreator
 						$element->pass_number = $passdata->getPass() + 1;
 						$element->pass_scored = $userdata->getScoredPass() == $passdata->getPass();
 						$element->pass_working_time = $passdata->getWorkingTime();
-						$element->pass_finish_date = $this->testObj->getPassFinishDate($active_id, $passdata->getPass());
+						$element->pass_finish_date = $this->testObj->lookupLastTestPassAccess($active_id, $pass);
 						$element->pass_reached_points = $passdata->getReachedPoints();
 
 						$this->participants->add($element);


### PR DESCRIPTION
Comment from Björn Heyser:
Ich habe in folgendem Commit etwas umgebaut. Die Methode die Du verwendet hast, habe ich so belassen aber umbenannt.
Warum? Sie heißt nun so wie das was sie auch macht ^^ Willst Du ein PassFinish Date oder ein PassDatasetUpdateTimestamp?
(Pass Daten werden ja auch aktualisiert wenn Manual Scoring oder Corrections Tab verwendet werden)

Für das reale Pass Finish Date bzw. den letzten Teilnehmer Zugriff auf einen Pass gibts nun:

ilObjTest::lookupLastTestPassAccess()

Das macht auch was es soll und liest es an anderer Stelle auf, dort wo nix mehr akualisiert wird, wenn der Teilnehmer durch ist ;-)

Hier mein Commit: https://github.com/ILIAS-eLearning/ILIAS/commit/a72e076cb97a8790b31d72bf1263216d0991c722

Liebe Grüße, Björn
