### PR TITLE
Fix typo in link to puppeteer.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The actual PDF rendering is done by a headless browser which has to be installed
 supports two renderers:
 
 * PhantomJS (deprecated), see [Installation](./docs/install-phantomjs.md)
-* Puppeteer via Browsershot (beta), see [Installation](./docs/install-pupeteer.md)
+* Puppeteer via Browsershot (beta), see [Installation](./docs/install-puppeteer.md)
 
 Issues
 ------


### PR DESCRIPTION
Maybe the text should also be adapted: "Browsershot via Puppeteer (beta): "